### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/black_n_pylint.yml
+++ b/.github/workflows/black_n_pylint.yml
@@ -4,6 +4,8 @@ on: [push]
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/CTimmerman/tk_image_viewer/security/code-scanning/1](https://github.com/CTimmerman/tk_image_viewer/security/code-scanning/1)

To remedy the issue, add a `permissions` block specifying read access to repository contents. This is best done at the job level (within the `build:` job definition), ensuring least privilege is applied only to this job, but it may also be placed at the workflow root if all jobs require only read access. The preferred minimal block is:
```yaml
permissions:
  contents: read
```
Specifically, add these lines directly beneath the job declaration (under `build:` and before `runs-on:`) in `.github/workflows/black_n_pylint.yml`. No new imports or package installations are required, as this is a YAML change affecting workflow configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
